### PR TITLE
Wire memory view parameters with rendering code

### DIFF
--- a/packages/cpp-debug/src/browser/cpp-memory-widget.tsx
+++ b/packages/cpp-debug/src/browser/cpp-memory-widget.tsx
@@ -109,6 +109,11 @@ export class MemoryView extends ReactWidget {
     protected bytesPerGroup: number = 1;
     protected endianness: Endianness = 'le';
 
+    // Parameters for the rendering of the memory contents.
+    protected bytesPerRow: number = 16;
+    protected bytesPerGroup: number = 1;
+    protected endianness: Endianness = 'le';
+
     @inject(MemoryProvider)
     protected readonly memoryProvider!: MemoryProvider;
 

--- a/packages/cpp-debug/src/browser/style/index.css
+++ b/packages/cpp-debug/src/browser/style/index.css
@@ -120,3 +120,7 @@ table#t-mv-view .t-mv-view-address {
     font-weight: 700;
     text-align: center;
 }
+
+#t-mv-length {
+    width: 4em;
+}


### PR DESCRIPTION
Make bytes per group and bytes per row effective.  Also, add an option
to select the endianness.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>